### PR TITLE
Bump STBlade.Modding.TLD.Il2CppAssemblies.Windows from 2.35.0 to 2.42.0

### DIFF
--- a/Source/UniversalTweaks.csproj
+++ b/Source/UniversalTweaks.csproj
@@ -23,7 +23,7 @@
 
 	<!-- List of used references -->
 	<ItemGroup>
-		<PackageReference Include="STBlade.Modding.TLD.Il2CppAssemblies.Windows" Version="2.35.0" />
+		<PackageReference Include="STBlade.Modding.TLD.Il2CppAssemblies.Windows" Version="2.42.0" />
 		<PackageReference Include="STBlade.Modding.TLD.LocalizationUtilities" Version="2.0.0" />
 		<PackageReference Include="STBlade.Modding.TLD.ModSettings" Version="1.9.0" />
 	</ItemGroup>


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: STBlade.Modding.TLD.Il2CppAssemblies.Windows dependency-version: 2.42.0 dependency-type: direct:production update-type: version-update:semver-minor ...